### PR TITLE
Added the ability to still utilize custom errors while in debug mode by ...

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1371,7 +1371,7 @@ class Slim
         } catch (\Slim\Exception\Stop $e) {
             $this->response()->write(ob_get_clean());
         } catch (\Exception $e) {
-            if ($this->config('debug')) {
+            if (true !== $this->config('custom_errors') && $this->config('debug')) {
                 throw $e;
             } else {
                 try {


### PR DESCRIPTION
...setting the configuration option 'custom_errors' to true. If option is set to anything except boolean true (or omitted) behavior will be the same as it currently is.
